### PR TITLE
Pre-compile YAStack tree in docker image

### DIFF
--- a/packaging/Dockerfile.essential
+++ b/packaging/Dockerfile.essential
@@ -1,0 +1,44 @@
+ARG DPDK_VERSION=18.05
+ARG OS_VER=18.10
+FROM ubuntu:${OS_VER}
+
+RUN apt-get update && apt-get install -y \
+    g++-5 \
+    gcc-5 \
+	libnuma-dev \
+    linux-headers-$(uname -r) \
+    autoconf \
+    make \
+    automake \
+    ethtool \
+    net-tools \
+    wget \
+    unzip \
+    tar \
+    tree \
+    git \
+    libunwind8 \
+    apt-transport-https \
+    libtool \
+    gawk \
+    libc-ares-dev \
+    python \
+    libz-dev \
+    golang-go \
+    curl \
+    && rm -rf /var/lib/apt/lists/* 
+
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 10 \
+update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 20 \
+update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 10 \
+update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 20 \
+update-alternatives --install /usr/bin/cc cc /usr/bin/gcc 30 \
+update-alternatives --set cc /usr/bin/gcc \
+update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 30 \
+update-alternatives --set c++ /usr/bin/g++ \
+
+
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.14.2/cmake-3.14.2.tar.gz
+RUN tar -xvzf cmake-3.14.2.tar.gz
+RUN cd cmake-3.14.2/ && ./bootstrap && make && make install
+RUN rm cmake-3.14.2.tar.gz

--- a/packaging/Dockerfile.essential
+++ b/packaging/Dockerfile.essential
@@ -28,17 +28,25 @@ RUN apt-get update && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/* 
 
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 10 \
-update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 20 \
-update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 10 \
-update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 20 \
-update-alternatives --install /usr/bin/cc cc /usr/bin/gcc 30 \
-update-alternatives --set cc /usr/bin/gcc \
-update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 30 \
-update-alternatives --set c++ /usr/bin/g++ \
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 10  
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 20 
+RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 10 
+RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 20 
+RUN update-alternatives --install /usr/bin/cc cc /usr/bin/gcc 30
+RUN update-alternatives --set cc /usr/bin/gcc 
+RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 30 
+RUN update-alternatives --set c++ /usr/bin/g++
 
 
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.14.2/cmake-3.14.2.tar.gz
 RUN tar -xvzf cmake-3.14.2.tar.gz
 RUN cd cmake-3.14.2/ && ./bootstrap && make && make install
 RUN rm cmake-3.14.2.tar.gz
+
+# # Install cmake
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.14.2/cmake-3.14.2.tar.gz
+RUN tar -xvzf cmake-3.14.2.tar.gz
+RUN cd cmake-3.14.2/ && ./bootstrap && make && make install
+
+# # Copy static binaries protoc and protoc-gen-validate
+COPY protoc-gen-validate /bin 

--- a/packaging/docker_build_essential_cmd.sh
+++ b/packaging/docker_build_essential_cmd.sh
@@ -1,0 +1,1 @@
+docker build -f ./Dockerfile.essential -t ubuntu/base:latest .


### PR DESCRIPTION
Hi, please review this PR.
Trying to build the actual image I'm experiencing in the following error
```
E: Unable to locate package linux-headers-4.18.0-20-generic
E: Couldn't find any package by glob 'linux-headers-4.18.0-20-generic'
E: Couldn't find any package by regex 'linux-headers-4.18.0-20-generic'
```

I' ve created a base image with ubuntu 18.10. IMHO can be useful to decouple OS image layer from yastack image 